### PR TITLE
Add flatpak org.freedesktop.secrets access

### DIFF
--- a/com.mardojai.ForgeSparks.json
+++ b/com.mardojai.ForgeSparks.json
@@ -10,7 +10,8 @@
     "--socket=wayland",
     "--device=dri",
     "--share=network",
-    "--talk-name=org.a11y.Bus"
+    "--talk-name=org.a11y.Bus",
+    "--talk-name=org.freedesktop.secrets"
   ],
   "modules": [
     {

--- a/com.mardojai.ForgeSparksDevel.json
+++ b/com.mardojai.ForgeSparksDevel.json
@@ -10,7 +10,8 @@
     "--socket=wayland",
     "--device=dri",
     "--share=network",
-    "--talk-name=org.a11y.Bus"
+    "--talk-name=org.a11y.Bus",
+    "--talk-name=org.freedesktop.secrets"
   ],
   "modules": [
     {


### PR DESCRIPTION
Access to org.freedesktop.secrets is required in order to add accounts when using the secrets store

Fixes https://github.com/rafaelmardojai/forge-sparks/issues/19