### PR TITLE
Appstream related patches

### DIFF
--- a/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
+++ b/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
@@ -67,6 +67,18 @@
     <display_length compare="ge">360</display_length>
   </requires>
 
+  <categories>
+    <category>GNOME</category>
+    <category>GTK</category>
+    <category>Network</category>
+  </categories>
+
+  <keywords>
+    <keyword translate="no">git</keyword>
+    <keyword translate="no">github</keyword>
+    <keyword>notifications</keyword>
+  </keywords>
+
   <recommends>
     <control>keyboard</control>
     <control>pointing</control>

--- a/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
+++ b/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
@@ -34,8 +34,8 @@
     </screenshot>
   </screenshots>
 
-  <releases translatable="no">
-  <release version="0.2.0" date="2023-09-20">
+  <releases>
+    <release version="0.2.0" date="2023-09-20">
       <description translatable="no">
         <ul>
           <li>Improved initial view</li>

--- a/data/meson.build
+++ b/data/meson.build
@@ -35,10 +35,10 @@ appstream_file = i18n.merge_file(
   install_dir: datadir / 'metainfo'
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate-relax', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', appstream_file]
   )
 endif
 


### PR DESCRIPTION
### appdata: Use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### appdata: Remove redundant marking

There is no meaning to mark the releases tag untranslatable.
Gettext ignores this marking.

### appdata: Update appdata

- Add categories and keywords tags

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-categories
