### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/com.mardojai.ForgeSparksDevel.json
+++ b/com.mardojai.ForgeSparksDevel.json
@@ -46,6 +46,7 @@
       "name": "forge-sparks",
       "buildsystem": "meson",
       "builddir": true,
+      "run-tests": true,
       "config-opts": [
         "-Dprofile=development"
       ],

--- a/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
+++ b/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
@@ -67,18 +67,6 @@
     <display_length compare="ge">360</display_length>
   </requires>
 
-  <categories>
-    <category>GNOME</category>
-    <category>GTK</category>
-    <category>Network</category>
-  </categories>
-
-  <keywords>
-    <keyword translate="no">git</keyword>
-    <keyword translate="no">github</keyword>
-    <keyword>notifications</keyword>
-  </keywords>
-
   <recommends>
     <control>keyboard</control>
     <control>pointing</control>

--- a/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
+++ b/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
@@ -13,7 +13,11 @@
   <url type="donation">https://mardojai.com/donate/</url>
   <url type="translate">https://hosted.weblate.org/engage/forge-sparks/</url>
   <url type="vcs-browser">https://github.com/rafaelmardojai/forge-sparks</url>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Rafael Mardojai CM</developer_name>
+  <developer id="github.com">
+      <name translatable="no">Rafael Mardojai CM</name>
+  </developer>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
 
   <description>

--- a/data/meson.build
+++ b/data/meson.build
@@ -38,7 +38,8 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', appstream_file]
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
   )
 endif
 


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli arguments
- Activate meson tests on Flatpak manifest

### appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories