### PR TITLE
Update developer ID

### DIFF
--- a/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
+++ b/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
@@ -15,7 +15,7 @@
   <url type="vcs-browser">https://github.com/rafaelmardojai/forge-sparks</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Rafael Mardojai CM</developer_name>
-  <developer id="github.com">
+  <developer id="com.mardojai">
       <name translatable="no">Rafael Mardojai CM</name>
   </developer>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDs.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer