### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
+++ b/data/com.mardojai.ForgeSparks.metainfo.xml.in.in
@@ -4,7 +4,7 @@
   <launchable type="desktop-id">@app_id@.desktop</launchable>
   <translation type="gettext">@app_id@</translation>
 
-  <name translatable="no">Forge Sparks</name>
+  <name translate="no">Forge Sparks</name>
   <summary>Get Git forges notifications</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
@@ -14,9 +14,9 @@
   <url type="translate">https://hosted.weblate.org/engage/forge-sparks/</url>
   <url type="vcs-browser">https://github.com/rafaelmardojai/forge-sparks</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Rafael Mardojai CM</developer_name>
+  <developer_name translate="no">Rafael Mardojai CM</developer_name>
   <developer id="com.mardojai">
-      <name translatable="no">Rafael Mardojai CM</name>
+      <name translate="no">Rafael Mardojai CM</name>
   </developer>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
 
@@ -40,7 +40,7 @@
 
   <releases>
     <release version="0.2.0" date="2023-09-20">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Improved initial view</li>
           <li>Accounts management moved to a separate window</li>
@@ -51,12 +51,12 @@
       </description>
     </release>
     <release version="0.1.1" date="2023-05-29">
-      <description translatable="no">
+      <description translate="no">
         <p>Minimal improvements and fixes.</p>
       </description>
     </release>
     <release version="0.1.0" date="2023-05-26">
-      <description translatable="no">
+      <description translate="no">
         <p>Initial release.</p>
         <ul>
           <li>Support for Forgejo</li>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html