### PR TITLE
header bar: Move the main menu to the left.

### DIFF
--- a/src/window.blp
+++ b/src/window.blp
@@ -54,7 +54,7 @@ template $Gjs_Window : Adw.ApplicationWindow {
         Adw.HeaderBar {
           show-title: false;
 
-          [end]
+          [start]
           MenuButton {
             primary: true;
             menu-model: menu;

--- a/src/window.blp
+++ b/src/window.blp
@@ -148,7 +148,7 @@ template $Gjs_Window : Adw.ApplicationWindow {
             }
           }
 
-          [end]
+          [start]
           MenuButton {
             primary: true;
             menu-model: menu;


### PR DESCRIPTION
On vanilla GNOME systems, having the menu on the left looks nicer because it balances against the close button on the right.