### PR TITLE
fix(util): Set background status only if sandboxed

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -80,9 +80,11 @@ export function requestBackground(window, autostart=false, hidden=false) {
  * @param {String} message
  */
 export function setBackgroundStatus(message=_('Monitoring new notifications')) {
-    portal.set_background_status(message, null, (portal, result) => {
-        portal.set_background_status_finish(result);
-    });
+    if (Xdp.Portal.running_under_sandbox()) {
+        portal.set_background_status(message, null, (portal, result) => {
+            portal.set_background_status_finish(result);
+        });
+    }
 }
 
 /**


### PR DESCRIPTION
Without this, the following error message is shown if running the app outside of sandbox:
```JavaScript
(com.mardojai.ForgeSparks:262195): Gjs-CRITICAL **: 17:29:00.460: JS ERROR: Gio.IOErrorEnum: GDBus.Error:org.freedesktop.portal.Error.NotAllowed: Only sandboxed applications can set background status
setBackgroundStatus/<@resource:///com/mardojai/ForgeSparks/util.js:84:16
main@resource:///com/mardojai/ForgeSparks/main.js:28:24
run@resource:///org/gnome/gjs/modules/script/package.js:207:19
@file:///usr/bin/forge-sparks:28:43
@file:///usr/bin/forge-sparks:34:6
```