### PR TITLE
feat(github): allow private instances custom URL

### DIFF
--- a/src/forges/github.js
+++ b/src/forges/github.js
@@ -17,7 +17,7 @@ export default class GitHub extends Forge {
 
     static prettyName = 'GitHub';
 
-    static allowInstances = false;
+    static allowInstances = true;
 
     static defaultURL = 'github.com';
 
@@ -309,6 +309,6 @@ export default class GitHub extends Forge {
      * @returns {String} The resulting URI
      */
     buildURI(path, query = {}) {
-        return Forge.buildURI(GITHUB_API, path, query);
+        return Forge.buildURI(`api.${this.url}`, path, query);
     }
 };


### PR DESCRIPTION
This enables filling a custom URL for a GitHub private instance.

It's indeed now possible to contract with GitHub for a private instance installed on a dedicated infrastructure. It's something you can encounter in some IT companies (like mine).