### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/com.mardojai.ForgeSparks.desktop.in.in
+++ b/data/com.mardojai.ForgeSparks.desktop.in.in
@@ -7,6 +7,7 @@ Terminal=false
 Type=Application
 Categories=Network;GNOME;GTK;
 StartupNotify=true
+DBusActivatable=true
 Icon=@app_id@
 Keywords=git;github;notifications;
 X-GNOME-UsesNotifications=true

--- a/data/com.mardojai.ForgeSparks.service.in
+++ b/data/com.mardojai.ForgeSparks.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app_id@
+Exec=@bindir@/forge-sparks --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -60,6 +60,16 @@ if compile_schemas.found()
   )
 endif
 
+service_conf = configuration_data()
+service_conf.set('app_id', application_id)
+service_conf.set('bindir', bindir)
+configure_file(
+  input: 'com.mardojai.ForgeSparks.service.in',
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install_dir: datadir / 'dbus-1/services'
+)
+
 install_data(
   '@0@.svg'.format(application_id),
   install_dir: datadir / 'icons/hicolor/scalable/apps'


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html